### PR TITLE
Split customisation from functional CSS to improve reusability

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 *.log
 *.js
+bundle.css
+*.html
 bundle.*
 .DS_Store
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+SSH_KEY="${1:-/root/.ssh/id_rsa}"
+DOCKER_IMAGE="economistprod/node4-base"
+
+[[ ${NPM_TOKEN:-} = '' ]] && { echo "NPM_TOKEN empty"; exit 1; }
+[[ ${SAUCE_ACCESS_KEY:-} = '' ]] && { echo "SAUCE_ACCESS_KEY empty"; exit 2; }
+
+docker pull "${DOCKER_IMAGE}"
+
+exec docker run \
+    -v "${SSH_KEY}":/root/.ssh/id_rsa \
+    -v "$(pwd)":/code \
+    "${DOCKER_IMAGE}" \
+    /bin/sh -cx "\
+        trap 'chmod 777 node_modules -R' EXIT && \
+        cd /code && \
+        umask 000 && \
+        printf \"@economist:registry=https://registry.npmjs.org/\n//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n\" > ~/.npmrc && \
+        NODE_ENV=test npm i && \
+        echo SAUCE_USER=sublimino SAUCE_ACCESS_KEY=${SAUCE_ACCESS_KEY} npm t && \
+        { git config --global user.email 'ecprod@economist.com'; git config --global user.name 'GoCD'; true; } && \
+        { [ \"$(git rev-parse --abbrev-ref HEAD)\" != \"master\" ] || npm run pages; } ; \
+        RETURN_CODE=\$?; \
+        echo \"Build finished with status \${RETURN_CODE}\"; \
+        exit \${RETURN_CODE}
+    ";
+
+

--- a/example.css
+++ b/example.css
@@ -1,0 +1,4 @@
+@import '@economist/component-gridcss';
+@import '@economist/component-font-neutra2';
+@import 'index.css';
+@import 'world-if.css';

--- a/example.css
+++ b/example.css
@@ -2,3 +2,9 @@
 @import '@economist/component-font-neutra2';
 @import 'index.css';
 @import 'world-if.css';
+
+.generic-example .TabView--View a {
+  display: block;
+  float: left;
+  max-width: 25%;
+}

--- a/example.css
+++ b/example.css
@@ -2,9 +2,3 @@
 @import '@economist/component-font-neutra2';
 @import 'index.css';
 @import 'world-if.css';
-
-.generic-example .TabView--View a {
-  display: block;
-  float: left;
-  max-width: 25%;
-}

--- a/example.es6
+++ b/example.es6
@@ -5,83 +5,82 @@ export default (
   <div>
     <div className="generic-example">
       <TabView>
-        <div title="Politics">
-          <a href="#">
-            <figure className="TabView--View--Content">
-              <img src="http://lorempixel.com/g/300/169/cats"/>
-              <figcaption>this is the caption</figcaption>
-            </figure>
-          </a>
-          <a href="#">
-            <figure className="TabView--View--Content">
-              <img src="http://lorempixel.com/g/300/169/people"/>
-              <figcaption>this is the caption</figcaption>
-            </figure>
-          </a>
-          <a href="#">
-            <figure className="TabView--View--Content">
-              <img src="http://lorempixel.com/g/300/169/city"/>
-              <figcaption>this is the caption</figcaption>
-            </figure>
-          </a>
-          <a href="#">
-            <figure className="TabView--View--Content">
-              <img src="http://lorempixel.com/g/300/169/fashion"/>
-              <figcaption>this is the caption</figcaption>
-            </figure>
-          </a>
+        <div title="Tab 1">
+          <img src="http://lorempixel.com/g/400/500/nightlife" style={{ float: 'left' }}/>
+          Lorem ipsum dolor sit amet, an eam error laboramus conceptam. Eu quiså
+          iudicabit philosophia est. Ex noster phaedrum sapientem sed. Tacimates
+          reformidans vis cu, nec delectus suscipiantur id, sit unum regione
+          luptatum no. Option denique ei vim. Amet magna eripuit sit at.
+          Ius et dicam nominavi, per ea modus ancillae appetere. Ut platonem
+          democritum scripserit mel, ut ius eleifend periculis explicari,
+          summo epicuri honestatis cu pri. Atomorum scriptorem mel no.
+          Pri an tamquam fastidii electram. Ne regione mentitum posidonium ius.
+          Eum dicit offendit id. An vim perpetua forensibus referrentur.
+          Eos omittam ocurreret complectitur in, sed nonumy utroque cu.
+          Te oratio dolorum vocibus qui, ei agam autem has, everti cetero
+          petentium vix te. Vim ne harum facilisis, eum nonumy sapientem te.
+          Eius possit mel cu, dicunt dolorem reprehendunt ea vix, pro diam
+          ludus solet et.
+          Modus diceret lucilius duo cu. Eleifend petentium sed ei,
+          pri graeci consectetuer ut. At vim erat porro.
+          Ut pro ullum instructior.
+          Per no dictas appareat conceptam, dicunt omnium eum et.
+          Pro dicat aliquip et. Altera euripidis forensibus est ne.
+          Alia democritum ius ne, inermis feugait ex mea.
+          Vis ei solum postulant, adhuc paulo id est, unum nihil altera no quo.
+          Erat postea eloquentiam ut eam. Quidam audiam nostrum an vix,
+          ei graece perpetua eos.
         </div>
-        <div title="Business & Economics">
-          <a href="#">
-            <figure className="TabView--View--Content">
-              <img src="http://lorempixel.com/g/300/169/food"/>
-              <figcaption>this is the caption</figcaption>
-            </figure>
-          </a>
-          <a href="#">
-            <figure className="TabView--View--Content">
-              <img src="http://lorempixel.com/g/300/169/nightlife"/>
-              <figcaption>this is the caption</figcaption>
-            </figure>
-          </a>
-          <a href="#">
-            <figure className="TabView--View--Content">
-              <img src="http://lorempixel.com/g/300/169/sports"/>
-              <figcaption>this is the caption</figcaption>
-            </figure>
-          </a>
-          <a href="#">
-            <figure className="TabView--View--Content">
-              <img src="http://lorempixel.com/g/300/169/nature"/>
-              <figcaption>this is the caption</figcaption>
-            </figure>
-          </a>
+        <div title="Tab 2">
+          <img src="http://lorempixel.com/g/400/500/nightlife" style={{ float: 'left' }}/>
+          Lorem ipsum dolor sit amet, an eam error laboramus conceptam. Eu quiså
+          iudicabit philosophia est. Ex noster phaedrum sapientem sed. Tacimates
+          reformidans vis cu, nec delectus suscipiantur id, sit unum regione
+          luptatum no. Option denique ei vim. Amet magna eripuit sit at.
+          Ius et dicam nominavi, per ea modus ancillae appetere. Ut platonem
+          democritum scripserit mel, ut ius eleifend periculis explicari,
+          summo epicuri honestatis cu pri. Atomorum scriptorem mel no.
+          Pri an tamquam fastidii electram. Ne regione mentitum posidonium ius.
+          Eum dicit offendit id. An vim perpetua forensibus referrentur.
+          Eos omittam ocurreret complectitur in, sed nonumy utroque cu.
+          Te oratio dolorum vocibus qui, ei agam autem has, everti cetero
+          petentium vix te. Vim ne harum facilisis, eum nonumy sapientem te.
+          Eius possit mel cu, dicunt dolorem reprehendunt ea vix, pro diam
+          ludus solet et.
+          Modus diceret lucilius duo cu. Eleifend petentium sed ei,
+          pri graeci consectetuer ut. At vim erat porro.
+          Ut pro ullum instructior.
+          Per no dictas appareat conceptam, dicunt omnium eum et.
+          Pro dicat aliquip et. Altera euripidis forensibus est ne.
+          Alia democritum ius ne, inermis feugait ex mea.
+          Vis ei solum postulant, adhuc paulo id est, unum nihil altera no quo.
+          Erat postea eloquentiam ut eam. Quidam audiam nostrum an vix,
+          ei graece perpetua eos.
         </div>
-        <div title="Science & technology">
-          <a href="#">
-            <figure className="TabView--View--Content">
-              <img src="http://lorempixel.com/g/300/169/transport"/>
-              <figcaption>this is the caption</figcaption>
-            </figure>
-          </a>
-          <a href="#">
-            <figure className="TabView--View--Content">
-              <img src="http://lorempixel.com/g/300/169/abstract"/>
-              <figcaption>this is the caption</figcaption>
-            </figure>
-          </a>
-          <a href="#">
-            <figure className="TabView--View--Content">
-              <img src="http://lorempixel.com/g/300/169/technics"/>
-              <figcaption>this is the caption</figcaption>
-            </figure>
-          </a>
-          <a href="#">
-            <figure className="TabView--View--Content">
-              <img src="http://lorempixel.com/g/300/169/cats"/>
-              <figcaption>this is the caption</figcaption>
-            </figure>
-          </a>
+        <div title="Tab 3">
+          Lorem ipsum dolor sit amet, an eam error laboramus conceptam. Eu quiså
+          iudicabit philosophia est. Ex noster phaedrum sapientem sed. Tacimates
+           reformidans vis cu, nec delectus suscipiantur id, sit unum regione
+           luptatum no. Option denique ei vim. Amet magna eripuit sit at.
+           Ius et dicam nominavi, per ea modus ancillae appetere. Ut platonem
+           democritum scripserit mel, ut ius eleifend periculis explicari,
+           summo epicuri honestatis cu pri. Atomorum scriptorem mel no.
+           Pri an tamquam fastidii electram. Ne regione mentitum posidonium ius.
+           Eum dicit offendit id. An vim perpetua forensibus referrentur.
+           Eos omittam ocurreret complectitur in, sed nonumy utroque cu.
+           Te oratio dolorum vocibus qui, ei agam autem has, everti cetero
+           petentium vix te. Vim ne harum facilisis, eum nonumy sapientem te.
+           Eius possit mel cu, dicunt dolorem reprehendunt ea vix, pro diam
+           ludus solet et.
+           Modus diceret lucilius duo cu. Eleifend petentium sed ei,
+           pri graeci consectetuer ut. At vim erat porro.
+           Ut pro ullum instructior.
+           Per no dictas appareat conceptam, dicunt omnium eum et.
+           Pro dicat aliquip et. Altera euripidis forensibus est ne.
+           Alia democritum ius ne, inermis feugait ex mea.
+           Vis ei solum postulant, adhuc paulo id est, unum nihil altera no quo.
+           Erat postea eloquentiam ut eam. Quidam audiam nostrum an vix,
+           ei graece perpetua eos.
         </div>
         <div title="History">
           <a href="#">

--- a/example.es6
+++ b/example.es6
@@ -1,94 +1,152 @@
 import React from 'react';
-import TabView from './index.es6';
+import TabView from './index';
 
 export default (
-  <TabView>
-    <div title="Politics">
-      <a href="#">
-        <figure className="TabView--View--Content">
-          <img src="http://lorempixel.com/g/300/169/cats"/>
-          <figcaption>this is the caption</figcaption>
-        </figure>
-      </a>
-      <a href="#">
-        <figure className="TabView--View--Content">
-          <img src="http://lorempixel.com/g/300/169/people"/>
-          <figcaption>this is the caption</figcaption>
-        </figure>
-      </a>
-      <a href="#">
-        <figure className="TabView--View--Content">
-          <img src="http://lorempixel.com/g/300/169/city"/>
-          <figcaption>this is the caption</figcaption>
-        </figure>
-      </a>
-      <a href="#">
-        <figure className="TabView--View--Content">
-          <img src="http://lorempixel.com/g/300/169/fashion"/>
-          <figcaption>this is the caption</figcaption>
-        </figure>
-      </a>
+  <div>
+    <TabView>
+      <div title="Politics">
+        <a href="#">
+          <figure className="TabView--View--Content">
+            <img src="http://lorempixel.com/g/300/169/cats"/>
+            <figcaption>this is the caption</figcaption>
+          </figure>
+        </a>
+        <a href="#">
+          <figure className="TabView--View--Content">
+            <img src="http://lorempixel.com/g/300/169/people"/>
+            <figcaption>this is the caption</figcaption>
+          </figure>
+        </a>
+        <a href="#">
+          <figure className="TabView--View--Content">
+            <img src="http://lorempixel.com/g/300/169/city"/>
+            <figcaption>this is the caption</figcaption>
+          </figure>
+        </a>
+        <a href="#">
+          <figure className="TabView--View--Content">
+            <img src="http://lorempixel.com/g/300/169/fashion"/>
+            <figcaption>this is the caption</figcaption>
+          </figure>
+        </a>
+      </div>
+      <div title="Business & Economics">
+        <a href="#">
+          <figure className="TabView--View--Content">
+            <img src="http://lorempixel.com/g/300/169/food"/>
+            <figcaption>this is the caption</figcaption>
+          </figure>
+        </a>
+        <a href="#">
+          <figure className="TabView--View--Content">
+            <img src="http://lorempixel.com/g/300/169/nightlife"/>
+            <figcaption>this is the caption</figcaption>
+          </figure>
+        </a>
+        <a href="#">
+          <figure className="TabView--View--Content">
+            <img src="http://lorempixel.com/g/300/169/sports"/>
+            <figcaption>this is the caption</figcaption>
+          </figure>
+        </a>
+        <a href="#">
+          <figure className="TabView--View--Content">
+            <img src="http://lorempixel.com/g/300/169/nature"/>
+            <figcaption>this is the caption</figcaption>
+          </figure>
+        </a>
+      </div>
+    </TabView>
+    <p>Original World if version</p>
+    <div className="world-if">
+      <TabView>
+        <div title="Politics">
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/cats"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/people"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/city"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/fashion"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+        </div>
+        <div title="Business & Economics">
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/food"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/nightlife"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/sports"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/nature"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+        </div>
+        <div title="Science & technology">
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/transport"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/abstract"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/technics"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/cats"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+        </div>
+        <div title="History">
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/nightlife"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+        </div>
+      </TabView>
     </div>
-    <div title="Business & Economics">
-      <a href="#">
-        <figure className="TabView--View--Content">
-          <img src="http://lorempixel.com/g/300/169/food"/>
-          <figcaption>this is the caption</figcaption>
-        </figure>
-      </a>
-      <a href="#">
-        <figure className="TabView--View--Content">
-          <img src="http://lorempixel.com/g/300/169/nightlife"/>
-          <figcaption>this is the caption</figcaption>
-        </figure>
-      </a>
-      <a href="#">
-        <figure className="TabView--View--Content">
-          <img src="http://lorempixel.com/g/300/169/sports"/>
-          <figcaption>this is the caption</figcaption>
-        </figure>
-      </a>
-      <a href="#">
-        <figure className="TabView--View--Content">
-          <img src="http://lorempixel.com/g/300/169/nature"/>
-          <figcaption>this is the caption</figcaption>
-        </figure>
-      </a>
-    </div>
-    <div title="Science & technology">
-      <a href="#">
-        <figure className="TabView--View--Content">
-          <img src="http://lorempixel.com/g/300/169/transport"/>
-          <figcaption>this is the caption</figcaption>
-        </figure>
-      </a>
-      <a href="#">
-        <figure className="TabView--View--Content">
-          <img src="http://lorempixel.com/g/300/169/abstract"/>
-          <figcaption>this is the caption</figcaption>
-        </figure>
-      </a>
-      <a href="#">
-        <figure className="TabView--View--Content">
-          <img src="http://lorempixel.com/g/300/169/technics"/>
-          <figcaption>this is the caption</figcaption>
-        </figure>
-      </a>
-      <a href="#">
-        <figure className="TabView--View--Content">
-          <img src="http://lorempixel.com/g/300/169/cats"/>
-          <figcaption>this is the caption</figcaption>
-        </figure>
-      </a>
-    </div>
-    <div title="History">
-      <a href="#">
-        <figure className="TabView--View--Content">
-          <img src="http://lorempixel.com/g/300/169/nightlife"/>
-          <figcaption>this is the caption</figcaption>
-        </figure>
-      </a>
-    </div>
-  </TabView>
+  </div>
 );
-

--- a/example.es6
+++ b/example.es6
@@ -3,60 +3,96 @@ import TabView from './index';
 
 export default (
   <div>
-    <TabView>
-      <div title="Politics">
-        <a href="#">
-          <figure className="TabView--View--Content">
-            <img src="http://lorempixel.com/g/300/169/cats"/>
-            <figcaption>this is the caption</figcaption>
-          </figure>
-        </a>
-        <a href="#">
-          <figure className="TabView--View--Content">
-            <img src="http://lorempixel.com/g/300/169/people"/>
-            <figcaption>this is the caption</figcaption>
-          </figure>
-        </a>
-        <a href="#">
-          <figure className="TabView--View--Content">
-            <img src="http://lorempixel.com/g/300/169/city"/>
-            <figcaption>this is the caption</figcaption>
-          </figure>
-        </a>
-        <a href="#">
-          <figure className="TabView--View--Content">
-            <img src="http://lorempixel.com/g/300/169/fashion"/>
-            <figcaption>this is the caption</figcaption>
-          </figure>
-        </a>
-      </div>
-      <div title="Business & Economics">
-        <a href="#">
-          <figure className="TabView--View--Content">
-            <img src="http://lorempixel.com/g/300/169/food"/>
-            <figcaption>this is the caption</figcaption>
-          </figure>
-        </a>
-        <a href="#">
-          <figure className="TabView--View--Content">
-            <img src="http://lorempixel.com/g/300/169/nightlife"/>
-            <figcaption>this is the caption</figcaption>
-          </figure>
-        </a>
-        <a href="#">
-          <figure className="TabView--View--Content">
-            <img src="http://lorempixel.com/g/300/169/sports"/>
-            <figcaption>this is the caption</figcaption>
-          </figure>
-        </a>
-        <a href="#">
-          <figure className="TabView--View--Content">
-            <img src="http://lorempixel.com/g/300/169/nature"/>
-            <figcaption>this is the caption</figcaption>
-          </figure>
-        </a>
-      </div>
-    </TabView>
+    <div className="generic-example">
+      <TabView>
+        <div title="Politics">
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/cats"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/people"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/city"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/fashion"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+        </div>
+        <div title="Business & Economics">
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/food"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/nightlife"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/sports"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/nature"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+        </div>
+        <div title="Science & technology">
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/transport"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/abstract"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/technics"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/cats"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+        </div>
+        <div title="History">
+          <a href="#">
+            <figure className="TabView--View--Content">
+              <img src="http://lorempixel.com/g/300/169/nightlife"/>
+              <figcaption>this is the caption</figcaption>
+            </figure>
+          </a>
+        </div>
+      </TabView>
+    </div>
     <p>Original World if version</p>
     <div className="world-if">
       <TabView>

--- a/example.es6
+++ b/example.es6
@@ -93,7 +93,7 @@ export default (
       </TabView>
     </div>
     <p>Original World if version</p>
-    <div className="world-if">
+    <div className="WorldIfApp">
       <TabView>
         <div title="Politics">
           <a href="#">

--- a/example.js
+++ b/example.js
@@ -1,76 +1,354 @@
-import React from 'react';
-import TabView from './';
-import ImageCaption from '@economist/component-imagecaption';
+'use strict';
 
-var child = {
-  caption: "First caption",
-  src: "http://lorempixel.com/g/300/169/food",
-  href: "http://www.google.com"
-};
+exports.__esModule = true;
 
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-export default (
-  <TabView>
-    <div title="Business & Finance">
-    <div className="TabView--Views--Tint"></div>
-    <a href={child.href}>
-         <ImageCaption className="TabView--View--Content"  caption={child.caption} src={child.src}></ImageCaption>
-    </a>
-     <a href={child.href}>
-         <ImageCaption className="TabView--View--Content" caption={child.caption} src={child.src}></ImageCaption>
-    </a>
-     <a href={child.href}>
-         <ImageCaption className="TabView--View--Content" caption={child.caption} src={child.src}></ImageCaption>
-    </a>
-     <a href={child.href}>
-         <ImageCaption className="TabView--View--Content" caption={child.caption} src={child.src}></ImageCaption>
-    </a>
-    </div>
-    <div title="Politics">
-    <div className="TabView--Views--Tint"></div>
-     <a href={child.href}>
-         <ImageCaption className="TabView--View--Content" caption={child.caption} src={child.src}></ImageCaption>
-    </a>
-     <a href={child.href}>
-         <ImageCaption className="TabView--View--Content" caption={child.caption} src={child.src}></ImageCaption>
-    </a>
-     <a href={child.href}>
-         <ImageCaption className="TabView--View--Content" caption={child.caption} src={child.src}></ImageCaption>
-    </a>
-     <a href={child.href}>
-         <ImageCaption className="TabView--View--Content" caption={child.caption} src={child.src}></ImageCaption>
-    </a>
-    </div>
-    <div title="Science & Technology">
-    <div className="TabView--Views--Tint"></div>
-     <a href={child.href}>
-         <ImageCaption className="TabView--View--Content" caption={child.caption} src={child.src}></ImageCaption>
-    </a>
-     <a href={child.href}>
-         <ImageCaption className="TabView--View--Content" caption={child.caption} src={child.src}></ImageCaption>
-    </a>
-     <a href={child.href}>
-         <ImageCaption className="TabView--View--Content" caption={child.caption} src={child.src}></ImageCaption>
-    </a>
-     <a href={child.href}>
-         <ImageCaption className="TabView--View--Content" caption={child.caption} src={child.src}></ImageCaption>
-    </a>
-    </div>
-    <div title="History">
-    <div className="TabView--Views--Tint"></div>
-     <a href={child.href}>
-         <ImageCaption className="TabView--View--Content" caption={child.caption} src={child.src}></ImageCaption>
-    </a>
-     <a href={child.href}>
-         <ImageCaption className="TabView--View--Content" caption={child.caption} src={child.src}></ImageCaption>
-    </a>
-     <a href={child.href}>
-         <ImageCaption className="TabView--View--Content" caption={child.caption} src={child.src}></ImageCaption>
-    </a>
-     <a href={child.href}>
-         <ImageCaption className="TabView--View--Content" caption={child.caption} src={child.src}></ImageCaption>
-    </a>
-    </div>
-  </TabView>
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _index = require('./index');
+
+var _index2 = _interopRequireDefault(_index);
+
+exports['default'] = _react2['default'].createElement(
+  'div',
+  null,
+  _react2['default'].createElement(
+    _index2['default'],
+    null,
+    _react2['default'].createElement(
+      'div',
+      { title: 'Politics' },
+      _react2['default'].createElement(
+        'a',
+        { href: '#' },
+        _react2['default'].createElement(
+          'figure',
+          { className: 'TabView--View--Content' },
+          _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/cats' }),
+          _react2['default'].createElement(
+            'figcaption',
+            null,
+            'this is the caption'
+          )
+        )
+      ),
+      _react2['default'].createElement(
+        'a',
+        { href: '#' },
+        _react2['default'].createElement(
+          'figure',
+          { className: 'TabView--View--Content' },
+          _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/people' }),
+          _react2['default'].createElement(
+            'figcaption',
+            null,
+            'this is the caption'
+          )
+        )
+      ),
+      _react2['default'].createElement(
+        'a',
+        { href: '#' },
+        _react2['default'].createElement(
+          'figure',
+          { className: 'TabView--View--Content' },
+          _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/city' }),
+          _react2['default'].createElement(
+            'figcaption',
+            null,
+            'this is the caption'
+          )
+        )
+      ),
+      _react2['default'].createElement(
+        'a',
+        { href: '#' },
+        _react2['default'].createElement(
+          'figure',
+          { className: 'TabView--View--Content' },
+          _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/fashion' }),
+          _react2['default'].createElement(
+            'figcaption',
+            null,
+            'this is the caption'
+          )
+        )
+      )
+    ),
+    _react2['default'].createElement(
+      'div',
+      { title: 'Business & Economics' },
+      _react2['default'].createElement(
+        'a',
+        { href: '#' },
+        _react2['default'].createElement(
+          'figure',
+          { className: 'TabView--View--Content' },
+          _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/food' }),
+          _react2['default'].createElement(
+            'figcaption',
+            null,
+            'this is the caption'
+          )
+        )
+      ),
+      _react2['default'].createElement(
+        'a',
+        { href: '#' },
+        _react2['default'].createElement(
+          'figure',
+          { className: 'TabView--View--Content' },
+          _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/nightlife' }),
+          _react2['default'].createElement(
+            'figcaption',
+            null,
+            'this is the caption'
+          )
+        )
+      ),
+      _react2['default'].createElement(
+        'a',
+        { href: '#' },
+        _react2['default'].createElement(
+          'figure',
+          { className: 'TabView--View--Content' },
+          _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/sports' }),
+          _react2['default'].createElement(
+            'figcaption',
+            null,
+            'this is the caption'
+          )
+        )
+      ),
+      _react2['default'].createElement(
+        'a',
+        { href: '#' },
+        _react2['default'].createElement(
+          'figure',
+          { className: 'TabView--View--Content' },
+          _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/nature' }),
+          _react2['default'].createElement(
+            'figcaption',
+            null,
+            'this is the caption'
+          )
+        )
+      )
+    )
+  ),
+  _react2['default'].createElement(
+    'p',
+    null,
+    'Original World if version'
+  ),
+  _react2['default'].createElement(
+    'div',
+    { className: 'world-if' },
+    _react2['default'].createElement(
+      _index2['default'],
+      null,
+      _react2['default'].createElement(
+        'div',
+        { title: 'Politics' },
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/cats' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/people' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/city' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/fashion' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        )
+      ),
+      _react2['default'].createElement(
+        'div',
+        { title: 'Business & Economics' },
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/food' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/nightlife' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/sports' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/nature' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        )
+      ),
+      _react2['default'].createElement(
+        'div',
+        { title: 'Science & technology' },
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/transport' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/abstract' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/technics' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/cats' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        )
+      ),
+      _react2['default'].createElement(
+        'div',
+        { title: 'History' },
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/nightlife' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        )
+      )
+    )
+  )
 );
-
+module.exports = exports['default'];

--- a/example.js
+++ b/example.js
@@ -23,183 +23,20 @@ exports['default'] = _react2['default'].createElement(
       null,
       _react2['default'].createElement(
         'div',
-        { title: 'Politics' },
-        _react2['default'].createElement(
-          'a',
-          { href: '#' },
-          _react2['default'].createElement(
-            'figure',
-            { className: 'TabView--View--Content' },
-            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/cats' }),
-            _react2['default'].createElement(
-              'figcaption',
-              null,
-              'this is the caption'
-            )
-          )
-        ),
-        _react2['default'].createElement(
-          'a',
-          { href: '#' },
-          _react2['default'].createElement(
-            'figure',
-            { className: 'TabView--View--Content' },
-            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/people' }),
-            _react2['default'].createElement(
-              'figcaption',
-              null,
-              'this is the caption'
-            )
-          )
-        ),
-        _react2['default'].createElement(
-          'a',
-          { href: '#' },
-          _react2['default'].createElement(
-            'figure',
-            { className: 'TabView--View--Content' },
-            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/city' }),
-            _react2['default'].createElement(
-              'figcaption',
-              null,
-              'this is the caption'
-            )
-          )
-        ),
-        _react2['default'].createElement(
-          'a',
-          { href: '#' },
-          _react2['default'].createElement(
-            'figure',
-            { className: 'TabView--View--Content' },
-            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/fashion' }),
-            _react2['default'].createElement(
-              'figcaption',
-              null,
-              'this is the caption'
-            )
-          )
-        )
+        { title: 'Tab 1' },
+        _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/400/500/nightlife', style: { float: 'left' } }),
+        'Lorem ipsum dolor sit amet, an eam error laboramus conceptam. Eu quiså iudicabit philosophia est. Ex noster phaedrum sapientem sed. Tacimates reformidans vis cu, nec delectus suscipiantur id, sit unum regione luptatum no. Option denique ei vim. Amet magna eripuit sit at. Ius et dicam nominavi, per ea modus ancillae appetere. Ut platonem democritum scripserit mel, ut ius eleifend periculis explicari, summo epicuri honestatis cu pri. Atomorum scriptorem mel no. Pri an tamquam fastidii electram. Ne regione mentitum posidonium ius. Eum dicit offendit id. An vim perpetua forensibus referrentur. Eos omittam ocurreret complectitur in, sed nonumy utroque cu. Te oratio dolorum vocibus qui, ei agam autem has, everti cetero petentium vix te. Vim ne harum facilisis, eum nonumy sapientem te. Eius possit mel cu, dicunt dolorem reprehendunt ea vix, pro diam ludus solet et. Modus diceret lucilius duo cu. Eleifend petentium sed ei, pri graeci consectetuer ut. At vim erat porro. Ut pro ullum instructior. Per no dictas appareat conceptam, dicunt omnium eum et. Pro dicat aliquip et. Altera euripidis forensibus est ne. Alia democritum ius ne, inermis feugait ex mea. Vis ei solum postulant, adhuc paulo id est, unum nihil altera no quo. Erat postea eloquentiam ut eam. Quidam audiam nostrum an vix, ei graece perpetua eos.'
       ),
       _react2['default'].createElement(
         'div',
-        { title: 'Business & Economics' },
-        _react2['default'].createElement(
-          'a',
-          { href: '#' },
-          _react2['default'].createElement(
-            'figure',
-            { className: 'TabView--View--Content' },
-            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/food' }),
-            _react2['default'].createElement(
-              'figcaption',
-              null,
-              'this is the caption'
-            )
-          )
-        ),
-        _react2['default'].createElement(
-          'a',
-          { href: '#' },
-          _react2['default'].createElement(
-            'figure',
-            { className: 'TabView--View--Content' },
-            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/nightlife' }),
-            _react2['default'].createElement(
-              'figcaption',
-              null,
-              'this is the caption'
-            )
-          )
-        ),
-        _react2['default'].createElement(
-          'a',
-          { href: '#' },
-          _react2['default'].createElement(
-            'figure',
-            { className: 'TabView--View--Content' },
-            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/sports' }),
-            _react2['default'].createElement(
-              'figcaption',
-              null,
-              'this is the caption'
-            )
-          )
-        ),
-        _react2['default'].createElement(
-          'a',
-          { href: '#' },
-          _react2['default'].createElement(
-            'figure',
-            { className: 'TabView--View--Content' },
-            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/nature' }),
-            _react2['default'].createElement(
-              'figcaption',
-              null,
-              'this is the caption'
-            )
-          )
-        )
+        { title: 'Tab 2' },
+        _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/400/500/nightlife', style: { float: 'left' } }),
+        'Lorem ipsum dolor sit amet, an eam error laboramus conceptam. Eu quiså iudicabit philosophia est. Ex noster phaedrum sapientem sed. Tacimates reformidans vis cu, nec delectus suscipiantur id, sit unum regione luptatum no. Option denique ei vim. Amet magna eripuit sit at. Ius et dicam nominavi, per ea modus ancillae appetere. Ut platonem democritum scripserit mel, ut ius eleifend periculis explicari, summo epicuri honestatis cu pri. Atomorum scriptorem mel no. Pri an tamquam fastidii electram. Ne regione mentitum posidonium ius. Eum dicit offendit id. An vim perpetua forensibus referrentur. Eos omittam ocurreret complectitur in, sed nonumy utroque cu. Te oratio dolorum vocibus qui, ei agam autem has, everti cetero petentium vix te. Vim ne harum facilisis, eum nonumy sapientem te. Eius possit mel cu, dicunt dolorem reprehendunt ea vix, pro diam ludus solet et. Modus diceret lucilius duo cu. Eleifend petentium sed ei, pri graeci consectetuer ut. At vim erat porro. Ut pro ullum instructior. Per no dictas appareat conceptam, dicunt omnium eum et. Pro dicat aliquip et. Altera euripidis forensibus est ne. Alia democritum ius ne, inermis feugait ex mea. Vis ei solum postulant, adhuc paulo id est, unum nihil altera no quo. Erat postea eloquentiam ut eam. Quidam audiam nostrum an vix, ei graece perpetua eos.'
       ),
       _react2['default'].createElement(
         'div',
-        { title: 'Science & technology' },
-        _react2['default'].createElement(
-          'a',
-          { href: '#' },
-          _react2['default'].createElement(
-            'figure',
-            { className: 'TabView--View--Content' },
-            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/transport' }),
-            _react2['default'].createElement(
-              'figcaption',
-              null,
-              'this is the caption'
-            )
-          )
-        ),
-        _react2['default'].createElement(
-          'a',
-          { href: '#' },
-          _react2['default'].createElement(
-            'figure',
-            { className: 'TabView--View--Content' },
-            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/abstract' }),
-            _react2['default'].createElement(
-              'figcaption',
-              null,
-              'this is the caption'
-            )
-          )
-        ),
-        _react2['default'].createElement(
-          'a',
-          { href: '#' },
-          _react2['default'].createElement(
-            'figure',
-            { className: 'TabView--View--Content' },
-            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/technics' }),
-            _react2['default'].createElement(
-              'figcaption',
-              null,
-              'this is the caption'
-            )
-          )
-        ),
-        _react2['default'].createElement(
-          'a',
-          { href: '#' },
-          _react2['default'].createElement(
-            'figure',
-            { className: 'TabView--View--Content' },
-            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/cats' }),
-            _react2['default'].createElement(
-              'figcaption',
-              null,
-              'this is the caption'
-            )
-          )
-        )
+        { title: 'Tab 3' },
+        'Lorem ipsum dolor sit amet, an eam error laboramus conceptam. Eu quiså iudicabit philosophia est. Ex noster phaedrum sapientem sed. Tacimates reformidans vis cu, nec delectus suscipiantur id, sit unum regione luptatum no. Option denique ei vim. Amet magna eripuit sit at. Ius et dicam nominavi, per ea modus ancillae appetere. Ut platonem democritum scripserit mel, ut ius eleifend periculis explicari, summo epicuri honestatis cu pri. Atomorum scriptorem mel no. Pri an tamquam fastidii electram. Ne regione mentitum posidonium ius. Eum dicit offendit id. An vim perpetua forensibus referrentur. Eos omittam ocurreret complectitur in, sed nonumy utroque cu. Te oratio dolorum vocibus qui, ei agam autem has, everti cetero petentium vix te. Vim ne harum facilisis, eum nonumy sapientem te. Eius possit mel cu, dicunt dolorem reprehendunt ea vix, pro diam ludus solet et. Modus diceret lucilius duo cu. Eleifend petentium sed ei, pri graeci consectetuer ut. At vim erat porro. Ut pro ullum instructior. Per no dictas appareat conceptam, dicunt omnium eum et. Pro dicat aliquip et. Altera euripidis forensibus est ne. Alia democritum ius ne, inermis feugait ex mea. Vis ei solum postulant, adhuc paulo id est, unum nihil altera no quo. Erat postea eloquentiam ut eam. Quidam audiam nostrum an vix, ei graece perpetua eos.'
       ),
       _react2['default'].createElement(
         'div',

--- a/example.js
+++ b/example.js
@@ -65,7 +65,7 @@ exports['default'] = _react2['default'].createElement(
   ),
   _react2['default'].createElement(
     'div',
-    { className: 'world-if' },
+    { className: 'WorldIfApp' },
     _react2['default'].createElement(
       _index2['default'],
       null,

--- a/example.js
+++ b/example.js
@@ -16,124 +16,206 @@ exports['default'] = _react2['default'].createElement(
   'div',
   null,
   _react2['default'].createElement(
-    _index2['default'],
-    null,
+    'div',
+    { className: 'generic-example' },
     _react2['default'].createElement(
-      'div',
-      { title: 'Politics' },
+      _index2['default'],
+      null,
       _react2['default'].createElement(
-        'a',
-        { href: '#' },
+        'div',
+        { title: 'Politics' },
         _react2['default'].createElement(
-          'figure',
-          { className: 'TabView--View--Content' },
-          _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/cats' }),
+          'a',
+          { href: '#' },
           _react2['default'].createElement(
-            'figcaption',
-            null,
-            'this is the caption'
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/cats' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/people' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/city' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/fashion' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
           )
         )
       ),
       _react2['default'].createElement(
-        'a',
-        { href: '#' },
+        'div',
+        { title: 'Business & Economics' },
         _react2['default'].createElement(
-          'figure',
-          { className: 'TabView--View--Content' },
-          _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/people' }),
+          'a',
+          { href: '#' },
           _react2['default'].createElement(
-            'figcaption',
-            null,
-            'this is the caption'
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/food' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/nightlife' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/sports' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/nature' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
           )
         )
       ),
       _react2['default'].createElement(
-        'a',
-        { href: '#' },
+        'div',
+        { title: 'Science & technology' },
         _react2['default'].createElement(
-          'figure',
-          { className: 'TabView--View--Content' },
-          _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/city' }),
+          'a',
+          { href: '#' },
           _react2['default'].createElement(
-            'figcaption',
-            null,
-            'this is the caption'
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/transport' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/abstract' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/technics' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
+          )
+        ),
+        _react2['default'].createElement(
+          'a',
+          { href: '#' },
+          _react2['default'].createElement(
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/cats' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
           )
         )
       ),
       _react2['default'].createElement(
-        'a',
-        { href: '#' },
+        'div',
+        { title: 'History' },
         _react2['default'].createElement(
-          'figure',
-          { className: 'TabView--View--Content' },
-          _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/fashion' }),
+          'a',
+          { href: '#' },
           _react2['default'].createElement(
-            'figcaption',
-            null,
-            'this is the caption'
-          )
-        )
-      )
-    ),
-    _react2['default'].createElement(
-      'div',
-      { title: 'Business & Economics' },
-      _react2['default'].createElement(
-        'a',
-        { href: '#' },
-        _react2['default'].createElement(
-          'figure',
-          { className: 'TabView--View--Content' },
-          _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/food' }),
-          _react2['default'].createElement(
-            'figcaption',
-            null,
-            'this is the caption'
-          )
-        )
-      ),
-      _react2['default'].createElement(
-        'a',
-        { href: '#' },
-        _react2['default'].createElement(
-          'figure',
-          { className: 'TabView--View--Content' },
-          _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/nightlife' }),
-          _react2['default'].createElement(
-            'figcaption',
-            null,
-            'this is the caption'
-          )
-        )
-      ),
-      _react2['default'].createElement(
-        'a',
-        { href: '#' },
-        _react2['default'].createElement(
-          'figure',
-          { className: 'TabView--View--Content' },
-          _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/sports' }),
-          _react2['default'].createElement(
-            'figcaption',
-            null,
-            'this is the caption'
-          )
-        )
-      ),
-      _react2['default'].createElement(
-        'a',
-        { href: '#' },
-        _react2['default'].createElement(
-          'figure',
-          { className: 'TabView--View--Content' },
-          _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/nature' }),
-          _react2['default'].createElement(
-            'figcaption',
-            null,
-            'this is the caption'
+            'figure',
+            { className: 'TabView--View--Content' },
+            _react2['default'].createElement('img', { src: 'http://lorempixel.com/g/300/169/nightlife' }),
+            _react2['default'].createElement(
+              'figcaption',
+              null,
+              'this is the caption'
+            )
           )
         )
       )

--- a/index.css
+++ b/index.css
@@ -1,5 +1,4 @@
 .TabView {
-  overflow: hidden;
   position: relative;
 }
 
@@ -10,29 +9,13 @@
   margin: 0;
 }
 
-.TabView:before {
-  display: block;
-  content: "";
-  width: 100%;
-  padding-top: 18.5%;
-}
-
-.TabView--Container {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 100%;
-}
-
-.TabView--Header {
-  overflow: hidden;
-}
-
 .TabView--Tabs {
   list-style: none;
   height: 101%;
+}
+
+.TabView--Container {
+  overflow: hidden;
 }
 
 .TabView--Tab,
@@ -56,7 +39,7 @@
 }
 
 .TabView--Views {
-  height: 100%;
+  height: var(--TabView-inner-height, 200px);
   position: relative;
   left: 0;
 }
@@ -76,10 +59,15 @@
   left: 0px;
 }
 
-.TabView--View--Content {
-  height: 100%;
-  width: 25%;
-  display: inline-block;
-  position: relative;
-  cursor: pointer;
+@media only screen and (max-width: 840px) {
+  .TabView--Tab[data-active="true"] {
+    display: inline-table;
+    border-right: none;
+  }
+  .TabView--Tab {
+    display: none;
+  }
+  .TabView--more {
+    display: inline-table;
+  }
 }

--- a/index.css
+++ b/index.css
@@ -1,13 +1,11 @@
-@import '@economist/component-gridcss';
-@import '@economist/component-font-neutra2';
-
 .TabView {
-  max-width: 1200px;
   overflow: hidden;
   position: relative;
 }
 
-.TabView ul, li, .TabView--View--Content {
+.TabView ul,
+.TabView  li,
+.TabView--View--Content {
   padding: 0;
   margin: 0;
 }
@@ -19,7 +17,7 @@
   padding-top: 18.5%;
 }
 
-.TabView > .TabView--Container {
+.TabView--Container {
   position: absolute;
   top: 0;
   left: 0;
@@ -29,7 +27,6 @@
 }
 
 .TabView--Header {
-  background-color: #393f43;
   overflow: hidden;
 }
 
@@ -38,23 +35,12 @@
   height: 101%;
 }
 
-.TabView--Tab, .TabView--Tab[data-active="true"] {
-  font-family: "Neutra2Display-Medium";
-  padding: 10px 0 10px 10px;
-  text-transform: uppercase;
+.TabView--Tab,
+.TabView--Tab[data-active="true"] {
   display: table-cell;
-  color: #929CA2;
   width: 18%;
-  border-right: 1px solid #929CA2;
   cursor: pointer;
-  background-color: #ddd;
-  font-size: 22px;
-  line-height: 25px;
   height: 100%;
-}
-
-.TabView--Tab:hover {
-  background-color: #4F575C;
 }
 
 .TabView--Tab:nth-last-child(2) {
@@ -62,47 +48,17 @@
 }
 
 .TabView--Tab:nth-last-child(1) {
-  background: rgb(0,0,0); /* Old browsers */
-  background: -moz-linear-gradient(left, rgba(0,0,0,1) 0%, rgba(57,63,67,1) 100%); /* FF3.6+ */
-  background: -webkit-gradient(linear, left top, right top, color-stop(0%,rgba(0,0,0,1)), color-stop(100%,rgba(57,63,67,1))); /* Chrome,Safari4+ */
-  background: -webkit-linear-gradient(left, rgba(0,0,0,1) 0%,rgba(57,63,67,1) 100%); /* Chrome10+,Safari5.1+ */
-  background: -o-linear-gradient(left, rgba(0,0,0,1) 0%,rgba(57,63,67,1) 100%); /* Opera 11.10+ */
-  background: -ms-linear-gradient(left, rgba(0,0,0,1) 0%,rgba(57,63,67,1) 100%); /* IE10+ */
-  background: linear-gradient(to right, rgba(0,0,0,1) 0%,rgba(57,63,67,1) 100%); /* W3C */
   border-right: none;
 }
 
-.TabView--Tab[data-active="true"] {
-  color: #fff;
-  background-color: #e3120b;
-}
-
-.TabView--Tab:nth-child(2)[data-active="true"] {
-  background-color: #08c5b2;
-}
-
-.TabView--Tab:nth-child(3)[data-active="true"] {
-  background-color: #f39200;
-}
-
-.TabView--Tab:nth-child(4)[data-active="true"] {
-  background-color: #4e64b5;
-}
-
-.TabView--Tab:nth-child(5) {
+.TabView--more {
   display: none;
-}
-
-.TabView--Views--Container {
-  height: 80%;
-  background-color: #000;
 }
 
 .TabView--Views {
   height: 100%;
   position: relative;
   left: 0;
-  background-color: #000;
 }
 
 .TabView--View {
@@ -112,7 +68,6 @@
   position: absolute;
   transition: left 0.5s ease-in-out 0.5s;
   left: 100%;
-  background-color: #000;
 }
 
 .TabView--View[data-active="true"] {
@@ -127,115 +82,4 @@
   display: inline-block;
   position: relative;
   cursor: pointer;
-  background-color: #000;
-}
-
-.TabView--View--Content img {
-  height: 100%;
-  width: 100%;
-  opacity: 0.8;
-}
-
-.TabView--View--Content img:hover {
-  opacity: 1;
-}
-
-.TabView figcaption {
-  font-family: "Neutra2Display-Titling";
-  position: absolute;
-  pointer-events: none;
-  bottom: 10px;
-  left: 20px;
-  color: #fff;
-  font-size: 20px;
-  text-transform: uppercase;
-  text-shadow:  2px 2px 3px rgba(0, 0, 0, 0.5);
-  z-index: 10;
-}
-
-@media only screen and (max-width: 1080px) {
-  .TabView--Tab, .TabView--Tab[data-active="true"] {
-    font-size: 18px;
-    line-height: 18px;
-    padding: 11px 10px 10px 10px;
-  }
-  .TabView figcaption {
-    left: 10px;
-    font-size: 18px;
-  }
-}
-@media only screen and (max-width: 950px) {
-  .TabView--Tab, .TabView--Tab[data-active="true"] {
-    font-size: 16px;
-    line-height: 16px;
-  }
-  .TabView figcaption {
-    font-size: 16px;
-  }
-}
-@media only screen and (max-width: 840px) {
-  .TabView:before {
-    padding-top: 23%;
-  }
-  .TabView .margin_1 {
-    margin-left: 0% !important;
-  }
-  .TabView--Tab[data-active="true"] {
-    display: inline-table;
-    border-right: none;
-    width: calc(34% - 20px);
-  }
-  .TabView--Tab {
-    display: none;
-  }
-  .TabView--Tab:nth-child(5) {
-    display: inline-table;
-  }
-  .TabView--Tab:nth-child(5):hover {
-    background: none;
-    width: calc(66% - 20px);
-    background-color: #4F575C;
-  }
-}
-@media only screen and (max-width: 570px) {
-  .TabView {
-    margin-bottom: -4px;
-  }
-  .TabView:before {
-    padding-top: 73%;
-  }
-  .TabView--Tab, .TabView--Tab[data-active="true"] {
-    width: calc(50% - 20px);
-    border-right: none;
-    padding-top: 12px;
-  }
-  .TabView--Views--Container {
-    height: 91%;
-    overflow: hidden;
-  }
-  .TabView--View--Content {
-    width: 50%;
-    height: 50%;
-  }
-  .TabView--View--Content img {
-    width: 100%;
-    margin-top: -4px;
-  }
-  .TabView--Tab:nth-child(5) {
-    width: calc(50% - 20px);
-  }
-  .TabView--Tab:nth-child(5):hover {
-    background: none;
-    width: calc(50% - 20px);
-    background-color: #dedede;
-  }
-}
-@media only screen and (max-width: 470px) {
-   .TabView--Header {
-    height: 20%;
-  }
-  .TabView--Views--Container {
-    height: 82%;
-    overflow: hidden;
-  }
 }

--- a/index.css
+++ b/index.css
@@ -21,17 +21,8 @@
 .TabView--Tab,
 .TabView--Tab[data-active="true"] {
   display: table-cell;
-  width: 18%;
   cursor: pointer;
   height: 100%;
-}
-
-.TabView--Tab:nth-last-child(2) {
-  border-right: none;
-}
-
-.TabView--Tab:nth-last-child(1) {
-  border-right: none;
 }
 
 .TabView--more {
@@ -39,9 +30,11 @@
 }
 
 .TabView--Views {
-  height: var(--TabView-inner-height, 200px);
+  height: var(--TabView-inner-height, 400px);
   position: relative;
   left: 0;
+  overflow-y: scroll;
+  overflow-x: hidden;
 }
 
 .TabView--View {

--- a/index.es6
+++ b/index.es6
@@ -14,7 +14,7 @@ export default class TabView extends React.Component {
      this.state = {
        selectedIndex,
      };
-  }
+   }
 
   handleClick(selectedIndex) {
     if (selectedIndex >= this.props.children.length) {
@@ -35,14 +35,14 @@ export default class TabView extends React.Component {
                   <li
                     key={index} className="TabView--Tab"
                     data-active={this.state.selectedIndex === index}
-                    onClick={this.handleClick.bind(this, index) }
+                    onClick={this.handleClick.bind(this, index)}
                   >
                     {child.props.title}
                   </li>
                 );
               })}
               <li
-                onClick={this.handleClick.bind(this, (this.state.selectedIndex + 1)) }
+                onClick={this.handleClick.bind(this, (this.state.selectedIndex + 1))}
                 className="TabView--Tab TabView--more"
               >More</li>
             </ul>

--- a/index.es6
+++ b/index.es6
@@ -9,11 +9,11 @@ export default class TabView extends React.Component {
   }
 
    constructor(props) {
-    super(props);
-    const selectedIndex = this.props.selectedIndex || 0;
-    this.state = {
-      selectedIndex,
-    };
+     super(props);
+     const selectedIndex = this.props.selectedIndex || 0;
+     this.state = {
+       selectedIndex,
+     };
   }
 
   handleClick(selectedIndex) {
@@ -35,13 +35,16 @@ export default class TabView extends React.Component {
                   <li
                     key={index} className="TabView--Tab"
                     data-active={this.state.selectedIndex === index}
-                    onClick={this.handleClick.bind(this, index) }>
+                    onClick={this.handleClick.bind(this, index) }
+                  >
                     {child.props.title}
                   </li>
                 );
               })}
-              <li onClick={this.handleClick.bind(this, (this.state.selectedIndex + 1)) }
-              className="TabView--Tab">More</li>
+              <li
+                onClick={this.handleClick.bind(this, (this.state.selectedIndex + 1)) }
+                className="TabView--Tab TabView--more"
+              >More</li>
             </ul>
           </header>
           <div className="TabView--Views--Container">
@@ -51,7 +54,8 @@ export default class TabView extends React.Component {
                   <div
                     key={index}
                     className="TabView--View"
-                    data-active={this.state.selectedIndex === index}>
+                    data-active={this.state.selectedIndex === index}
+                  >
                     {child.props.children}
                   </div>
                 );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-tabview",
-  "version": "1.2.3",
+  "version": "2.0.0",
   "description": "A simple tabbed view",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -16,79 +16,149 @@
   "files": [
     "*.js",
     "*.css",
-    "assets/*"
+    "assets/*",
+    "!karma.conf.js",
+    "!testbundle.js"
   ],
-  "eslintConfig": {
-    "extends": "strict/react"
+  "browserify": {
+    "transform": [
+      "babelify"
+    ]
   },
-  "component-devserver": {
-    "example": "./example.es6",
+  "babel": {
+    "stage": 0,
+    "loose": "all",
+    "compact": false
+  },
+  "eslintConfig": {
+    "extends": [
+      "strict",
+      "strict-react"
+    ]
+  },
+  "devpack-doc": {
+    "demohtml": {
+      "cmd": "babel-node -p \"require('react').renderToString(require('./example'))\""
+    },
     "css": [
-      "/node_modules/mocha/mocha.css",
-      "/index.css"
+      {
+        "src": "./node_modules/mocha/mocha.css"
+      },
+      "./bundle.css"
     ],
     "js": [
-      "/node_modules/react/react.js?browserify&expose=react",
       {
-        "contents": "window.React = require('react');"
+        "src": "./node_modules/mocha/mocha.js"
       },
-      "/index.es6?babelify&debug&expose=index.es6&external=react",
-      "/example.es6?babelify&debug&expose=example.es6&external=react",
       {
-        "contents": "require('react').render(require('example.es6'),document.getElementById('component-preview'));"
+        "src": "./node_modules/chai/chai.js"
       },
-      "/node_modules/mocha/mocha.js",
-      "/node_modules/@economist/component-testharness/node_modules/chai/chai.js",
-      "/node_modules/@economist/component-testharness/node_modules/chai-things/lib/chai-things.js",
-      "/node_modules/@economist/component-testharness/node_modules/chai-as-promised/lib/chai-as-promised.js",
-      "/node_modules/@economist/component-testharness/node_modules/chai-spies/chai-spies.js",
+      {
+        "src": "./node_modules/chai-things/lib/chai-things.js"
+      },
+      {
+        "src": "./node_modules/chai-spies/chai-spies.js"
+      },
       {
         "contents": "chai.should();mocha.setup('bdd');"
       },
-      "/test/index.es6?babelify&debug&external=react",
+      "./testbundle.js",
       {
-        "contents": "mocha.checkLeaks();mocha.run();"
+        "contents": "window.React = require('react');"
+      },
+      {
+        "contents": "require('react').render(require('example'),document.getElementById('component-preview'));"
+      },
+      {
+        "contents": "if(document.getElementById('mocha')){mocha.checkLeaks();mocha.run();}"
       }
     ],
-    "html": [
+    "sections": [
       {
-        "contents": "<div class='component-panel'><h2 class='component-panel-heading'>Tests</h2><div id='mocha' class='test-output'></div></div>"
+        "title": "Readme",
+        "type": "markdown",
+        "src": "./README.md"
+      },
+      {
+        "title": "Example Code",
+        "type": "code",
+        "src": "./example.es6"
+      },
+      {
+        "title": "Tests",
+        "type": "html",
+        "contents": "<div id='mocha' class='test-output'></div>"
       }
     ]
   },
+  "watch": {
+    "doc:html": [
+      "README.md",
+      "./*.js",
+      "package.json"
+    ]
+  },
   "config": {
-    "lint_opts": "--ignore-path .gitignore --ext .es6"
+    "lint_opts": "--ignore-path .gitignore --ext .es6",
+    "testbundle_opts": "-r react -r .:./index.es6 -r ./example.js:example ./test/index.js -o testbundle.js",
+    "ghpages_files": "*.html *.css *.js assets/"
   },
   "scripts": {
     "build": "npm-assets .",
+    "ci": "./build.sh",
+    "doc": "parallelshell 'npm run doc:html' 'npm run doc:js' 'npm run doc:css'",
+    "doc:css": "cssnext --sourcemap example.css bundle.css",
+    "doc:css:watch": "npm run doc:css -- --watch",
+    "doc:html": "devpack-doc index standalone",
+    "doc:html:watch": "npm-watch",
+    "doc:js": "npm run prepublish && browserify -d $npm_package_config_testbundle_opts",
+    "doc:js:watch": "watchify $npm_package_config_testbundle_opts",
+    "doc:watch": "parallelshell 'npm run doc:html:watch' 'npm run doc:js:watch' 'npm run doc:css:watch'",
     "lint": "eslint $npm_package_config_lint_opts .",
-    "prepublish": "babel index.es6 --source-maps=inline --stage=0 --loose > index.js",
+    "pages": "git stash save -u pages-stash && git branch -D gh-pages; git checkout --orphan gh-pages && git add -f $npm_package_config_ghpages_files && git commit -anm'ghpages' && git push origin HEAD:gh-pages -f",
+    "prepages": "npm run build && npm run doc",
+    "prepublish": "babel . -d . -x .es6",
+    "prepublish:watch": "npm run prepublish -- -w",
+    "pretest": "npm run lint",
     "provision": "devpack-configure ./package.json",
-    "serve": "component-devserver .",
-    "test": "npm run test:base -- -R tap",
+    "serve": "browser-sync start --server --files '*.{html,js}'",
+    "test": "karma start",
     "test:base": "mocha -r babel/register -r @economist/component-testharness",
-    "test:watch": "npm run test:base -- -wR min"
+    "test:watch": "npm run test:base -- -wR min",
+    "watch": "parallelshell 'npm run doc:watch' 'npm run prepublish:watch' 'npm run serve'"
   },
   "dependencies": {
     "@economist/component-font-neutra2": "^1.0.4",
     "@economist/component-gridcss": "^2.0.0",
-    "react": "^0.13.3"
+    "react": "^0.14.0"
   },
   "devDependencies": {
-    "@economist/component-devpack": "^2.5.0",
-    "@economist/component-devserver": "^2.0.0",
+    "@economist/component-devpack": "^3.4.3",
     "@economist/component-imagecaption": "",
-    "@economist/component-testharness": "^1.1.0",
-    "babel": "^5.5.8",
-    "eslint": "^0.24.0",
-    "eslint-config-strict": "^2.4.0",
-    "eslint-plugin-filenames": "^0.1.1",
+    "babel": "^5.8.23",
+    "babelify": "^6.3.0",
+    "browser-sync": "^2.8.2",
+    "browserify": "^11.0.1",
+    "chai": "^3.2.0",
+    "chai-spies": "^0.6.0",
+    "chai-things": "^0.2.0",
+    "cssnext": "^1.8.4",
+    "eslint": "^1.3.1",
+    "eslint-config-strict": "^5.0.0",
+    "eslint-config-strict-react": "^2.0.0",
+    "eslint-plugin-filenames": "^0.1.2",
     "eslint-plugin-one-variable-per-var": "^0.0.3",
-    "eslint-plugin-react": "^2.6.3",
+    "eslint-plugin-react": "^3.3.1",
+    "karma-chai": "^0.1.0",
+    "karma-mocha": "^0.2.0",
+    "karma-sauce-launcher": "^0.2.14",
     "minifyify": "^7.0.1",
     "mocha": "^2.2.5",
     "npm-assets": "^0.1.0",
-    "pre-commit": "^1.0.10"
+    "npm-watch": "0.0.1",
+    "parallelshell": "^2.0.0",
+    "pre-commit": "^1.0.10",
+    "watchify": "^3.4.0"
   },
   "pre-commit": [
     "lint"

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,1 +1,1 @@
-{"extends":"strict/es6/mocha"}
+{"extends":["strict","strict-react","strict/mocha"]}

--- a/world-if.css
+++ b/world-if.css
@@ -25,11 +25,17 @@
   height: 100%;
 }
 
-.TabView--Header {
+.world-if .TabView--Views {
+  overflow-y: hidden;
+  overflow-x: hidden;
+}
+
+.world-if .TabView--Header {
   overflow: hidden;
 }
 
-.world-if .TabView--Tab, .world-if .TabView--Tab[data-active="true"] {
+.world-if .TabView--Tab,
+.world-if .TabView--Tab[data-active="true"] {
   font-family: "Neutra2Display-Medium";
   padding: 10px 0 10px 10px;
   text-transform: uppercase;
@@ -38,6 +44,7 @@
   background-color: #ddd;
   font-size: 22px;
   line-height: 25px;
+  width: 18%;
 }
 
 .world-if .TabView--Tab:hover {
@@ -46,6 +53,14 @@
 
 .world-if .TabView--Tab:nth-last-child(1) {
   background: rgb(0,0,0); /* Old browsers */
+}
+
+.world-if .TabView--Tab:nth-last-child(2) {
+  border-right: none;
+}
+
+.world-if .TabView--Tab:nth-last-child(1) {
+  border-right: none;
 }
 
 .world-if .TabView--Tab[data-active="true"] {

--- a/world-if.css
+++ b/world-if.css
@@ -1,0 +1,176 @@
+/* Added .world-if  prefix just for example/dev only, remove before production */
+.world-if .TabView {
+  max-width: 1200px;
+}
+
+.world-if .TabView--Header {
+  background-color: #393f43;
+  overflow: hidden;
+}
+
+.world-if .TabView--Tab, .world-if .TabView--Tab[data-active="true"] {
+  font-family: "Neutra2Display-Medium";
+  padding: 10px 0 10px 10px;
+  text-transform: uppercase;
+  color: #929CA2;
+  border-right: 1px solid #929CA2;
+  background-color: #ddd;
+  font-size: 22px;
+  line-height: 25px;
+}
+
+.world-if .TabView--Tab:hover {
+  background-color: #4F575C;
+}
+
+.world-if .TabView--Tab:nth-last-child(1) {
+  background: rgb(0,0,0); /* Old browsers */
+}
+
+.world-if .TabView--Tab[data-active="true"] {
+  color: #fff;
+  background-color: #e3120b;
+}
+
+.world-if .TabView--Tab:nth-child(2)[data-active="true"] {
+  background-color: #08c5b2;
+}
+
+.world-if .TabView--Tab:nth-child(3)[data-active="true"] {
+  background-color: #f39200;
+}
+
+.world-if .TabView--Tab:nth-child(4)[data-active="true"] {
+  background-color: #4e64b5;
+}
+
+.world-if .TabView--Views--Container {
+  height: 80%;
+  background-color: #000;
+}
+
+.world-if .TabView--Views {
+  height: 100%;
+  position: relative;
+  left: 0;
+}
+
+.world-if .TabView--View {
+  background-color: #000;
+}
+
+.world-if .TabView--View--Content {
+  background-color: #000;
+}
+
+.world-if .TabView--View--Content img {
+  height: 100%;
+  width: 100%;
+  opacity: 0.8;
+}
+
+.world-if .TabView--View--Content img:hover {
+  opacity: 1;
+}
+
+.world-if .TabView figcaption {
+  font-family: "Neutra2Display-Titling";
+  position: absolute;
+  pointer-events: none;
+  bottom: 10px;
+  left: 20px;
+  color: #fff;
+  font-size: 20px;
+  text-transform: uppercase;
+  text-shadow:  2px 2px 3px rgba(0, 0, 0, 0.5);
+  z-index: 10;
+}
+
+@media only screen and (max-width: 1080px) {
+  .world-if .TabView--Tab, .world-if .TabView--Tab[data-active="true"] {
+    font-size: 18px;
+    line-height: 18px;
+    padding: 11px 10px 10px 10px;
+  }
+  .world-if .TabView figcaption {
+    left: 10px;
+    font-size: 18px;
+  }
+}
+
+@media only screen and (max-width: 950px) {
+  .world-if .TabView--Tab, .world-if .TabView--Tab[data-active="true"] {
+    font-size: 16px;
+    line-height: 16px;
+  }
+  .world-if .TabView figcaption {
+    font-size: 16px;
+  }
+}
+
+@media only screen and (max-width: 840px) {
+  .world-if .TabView:before {
+    padding-top: 23%;
+  }
+  .world-if .TabView .margin_1 {
+    margin-left: 0% !important;
+  }
+  .world-if .TabView--Tab[data-active="true"] {
+    display: inline-table;
+    border-right: none;
+    width: calc(34% - 20px);
+  }
+  .world-if .TabView--Tab {
+    display: none;
+  }
+  .world-if .TabView--Tab:nth-child(5) {
+    display: inline-table;
+  }
+  .world-if .TabView--Tab:nth-child(5):hover {
+    background: none;
+    width: calc(66% - 20px);
+    background-color: #4F575C;
+  }
+}
+@media only screen and (max-width: 570px) {
+  .world-if .TabView {
+    margin-bottom: -4px;
+  }
+  .world-if .TabView:before {
+    padding-top: 73%;
+  }
+  .world-if .TabView--Tab, .world-if .TabView--Tab[data-active="true"] {
+    width: calc(50% - 20px);
+    border-right: none;
+    padding-top: 12px;
+  }
+  .world-if .TabView--Views--Container {
+    height: 91%;
+    overflow: hidden;
+  }
+  .world-if .TabView--View--Content {
+    width: 50%;
+    height: 50%;
+  }
+  .world-if .TabView--View--Content img {
+    width: 100%;
+    margin-top: -4px;
+  }
+  .world-if .TabView--Tab:nth-child(5) {
+    width: calc(50% - 20px);
+  }
+  .world-if .TabView--Tab:nth-child(5):hover {
+    background: none;
+    width: calc(50% - 20px);
+    background-color: #dedede;
+  }
+}
+@media only screen and (max-width: 470px) {
+   .world-if .TabView--Header {
+    height: 20%;
+  }
+  .world-if .TabView--Views--Container {
+    height: 82%;
+    overflow: hidden;
+  }
+}

--- a/world-if.css
+++ b/world-if.css
@@ -1,22 +1,21 @@
-/* Added .world-if  prefix just for example/dev only, remove before production */
-.world-if .TabView {
+.WorldIfApp .TabView {
   overflow: hidden;
   max-width: 1200px;
 }
 
-.world-if .TabView--Header {
+.WorldIfApp .TabView--Header {
   background-color: #393f43;
   overflow: hidden;
 }
 
-.world-if .TabView:before {
+.WorldIfApp .TabView:before {
   display: block;
   content: "";
   width: 100%;
   padding-top: 18.5%;
 }
 
-.world-if .TabView--Container {
+.WorldIfApp .TabView--Container {
   position: absolute;
   top: 0;
   left: 0;
@@ -25,17 +24,17 @@
   height: 100%;
 }
 
-.world-if .TabView--Views {
+.WorldIfApp .TabView--Views {
   overflow-y: hidden;
   overflow-x: hidden;
 }
 
-.world-if .TabView--Header {
+.WorldIfApp .TabView--Header {
   overflow: hidden;
 }
 
-.world-if .TabView--Tab,
-.world-if .TabView--Tab[data-active="true"] {
+.WorldIfApp .TabView--Tab,
+.WorldIfApp .TabView--Tab[data-active="true"] {
   font-family: "Neutra2Display-Medium";
   padding: 10px 0 10px 10px;
   text-transform: uppercase;
@@ -47,69 +46,69 @@
   width: 18%;
 }
 
-.world-if .TabView--Tab:hover {
+.WorldIfApp .TabView--Tab:hover {
   background-color: #4F575C;
 }
 
-.world-if .TabView--Tab:nth-last-child(1) {
+.WorldIfApp .TabView--Tab:nth-last-child(1) {
   background: rgb(0,0,0); /* Old browsers */
 }
 
-.world-if .TabView--Tab:nth-last-child(2) {
+.WorldIfApp .TabView--Tab:nth-last-child(2) {
   border-right: none;
 }
 
-.world-if .TabView--Tab:nth-last-child(1) {
+.WorldIfApp .TabView--Tab:nth-last-child(1) {
   border-right: none;
 }
 
-.world-if .TabView--Tab[data-active="true"] {
+.WorldIfApp .TabView--Tab[data-active="true"] {
   color: #fff;
   background-color: #e3120b;
 }
 
-.world-if .TabView--Tab:nth-child(2)[data-active="true"] {
+.WorldIfApp .TabView--Tab:nth-child(2)[data-active="true"] {
   background-color: #08c5b2;
 }
 
-.world-if .TabView--Tab:nth-child(3)[data-active="true"] {
+.WorldIfApp .TabView--Tab:nth-child(3)[data-active="true"] {
   background-color: #f39200;
 }
 
-.world-if .TabView--Tab:nth-child(4)[data-active="true"] {
+.WorldIfApp .TabView--Tab:nth-child(4)[data-active="true"] {
   background-color: #4e64b5;
 }
 
-.world-if .TabView--Views--Container {
+.WorldIfApp .TabView--Views--Container {
   height: 80%;
   background-color: #000;
 }
 
-.world-if .TabView--Views {
+.WorldIfApp .TabView--Views {
   height: 100%;
   position: relative;
   left: 0;
 }
 
-.world-if .TabView--View {
+.WorldIfApp .TabView--View {
   background-color: #000;
 }
 
-.world-if .TabView--View--Content {
+.WorldIfApp .TabView--View--Content {
   background-color: #000;
 }
 
-.world-if .TabView--View--Content img {
+.WorldIfApp .TabView--View--Content img {
   height: 100%;
   width: 100%;
   opacity: 0.8;
 }
 
-.world-if .TabView--View--Content img:hover {
+.WorldIfApp .TabView--View--Content img:hover {
   opacity: 1;
 }
 
-.world-if .TabView figcaption {
+.WorldIfApp .TabView figcaption {
   font-family: "Neutra2Display-Titling";
   position: absolute;
   pointer-events: none;
@@ -122,7 +121,7 @@
   z-index: 10;
 }
 
-.world-if .TabView--View--Content {
+.WorldIfApp .TabView--View--Content {
   height: 100%;
   width: 25%;
   display: inline-block;
@@ -131,83 +130,83 @@
 }
 
 @media only screen and (max-width: 1080px) {
-  .world-if .TabView--Tab, .world-if .TabView--Tab[data-active="true"] {
+  .WorldIfApp .TabView--Tab, .WorldIfApp .TabView--Tab[data-active="true"] {
     font-size: 18px;
     line-height: 18px;
     padding: 11px 10px 10px 10px;
   }
-  .world-if .TabView figcaption {
+  .WorldIfApp .TabView figcaption {
     left: 10px;
     font-size: 18px;
   }
 }
 
 @media only screen and (max-width: 950px) {
-  .world-if .TabView--Tab, .world-if .TabView--Tab[data-active="true"] {
+  .WorldIfApp .TabView--Tab, .WorldIfApp .TabView--Tab[data-active="true"] {
     font-size: 16px;
     line-height: 16px;
   }
-  .world-if .TabView figcaption {
+  .WorldIfApp .TabView figcaption {
     font-size: 16px;
   }
 }
 
 @media only screen and (max-width: 840px) {
-  .world-if .TabView:before {
+  .WorldIfApp .TabView:before {
     padding-top: 23%;
   }
-  .world-if .TabView .margin_1 {
+  .WorldIfApp .TabView .margin_1 {
     margin-left: 0% !important;
   }
-  .world-if .TabView--Tab[data-active="true"] {
+  .WorldIfApp .TabView--Tab[data-active="true"] {
     border-right: none;
     width: calc(34% - 20px);
   }
-  .world-if .TabView--more,
-  .world-if .TabView--more:hover {
+  .WorldIfApp .TabView--more,
+  .WorldIfApp .TabView--more:hover {
     background: none;
     width: calc(66% - 20px);
     background-color: #4F575C;
   }
 }
 @media only screen and (max-width: 570px) {
-  .world-if .TabView {
+  .WorldIfApp .TabView {
     margin-bottom: -4px;
   }
-  .world-if .TabView:before {
+  .WorldIfApp .TabView:before {
     padding-top: 73%;
   }
-  .world-if .TabView--Tab, .world-if .TabView--Tab[data-active="true"] {
+  .WorldIfApp .TabView--Tab, .WorldIfApp .TabView--Tab[data-active="true"] {
     width: calc(50% - 20px);
     border-right: none;
     padding-top: 12px;
   }
-  .world-if .TabView--Views--Container {
+  .WorldIfApp .TabView--Views--Container {
     height: 91%;
     overflow: hidden;
   }
-  .world-if .TabView--View--Content {
+  .WorldIfApp .TabView--View--Content {
     width: 50%;
     height: 50%;
   }
-  .world-if .TabView--View--Content img {
+  .WorldIfApp .TabView--View--Content img {
     width: 100%;
     margin-top: -4px;
   }
-  .world-if .TabView--more {
+  .WorldIfApp .TabView--more {
     width: calc(50% - 20px);
   }
-  .world-if .TabView--more:hover {
+  .WorldIfApp .TabView--more:hover {
     background: none;
     width: calc(50% - 20px);
     background-color: #dedede;
   }
 }
 @media only screen and (max-width: 470px) {
-   .world-if .TabView--Header {
+   .WorldIfApp .TabView--Header {
     height: 20%;
   }
-  .world-if .TabView--Views--Container {
+  .WorldIfApp .TabView--Views--Container {
     height: 82%;
     overflow: hidden;
   }

--- a/world-if.css
+++ b/world-if.css
@@ -1,10 +1,31 @@
 /* Added .world-if  prefix just for example/dev only, remove before production */
 .world-if .TabView {
+  overflow: hidden;
   max-width: 1200px;
 }
 
 .world-if .TabView--Header {
   background-color: #393f43;
+  overflow: hidden;
+}
+
+.world-if .TabView:before {
+  display: block;
+  content: "";
+  width: 100%;
+  padding-top: 18.5%;
+}
+
+.world-if .TabView--Container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 100%;
+}
+
+.TabView--Header {
   overflow: hidden;
 }
 
@@ -86,6 +107,14 @@
   z-index: 10;
 }
 
+.world-if .TabView--View--Content {
+  height: 100%;
+  width: 25%;
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+}
+
 @media only screen and (max-width: 1080px) {
   .world-if .TabView--Tab, .world-if .TabView--Tab[data-active="true"] {
     font-size: 18px;
@@ -116,17 +145,11 @@
     margin-left: 0% !important;
   }
   .world-if .TabView--Tab[data-active="true"] {
-    display: inline-table;
     border-right: none;
     width: calc(34% - 20px);
   }
-  .world-if .TabView--Tab {
-    display: none;
-  }
-  .world-if .TabView--Tab:nth-child(5) {
-    display: inline-table;
-  }
-  .world-if .TabView--Tab:nth-child(5):hover {
+  .world-if .TabView--more,
+  .world-if .TabView--more:hover {
     background: none;
     width: calc(66% - 20px);
     background-color: #4F575C;
@@ -156,10 +179,10 @@
     width: 100%;
     margin-top: -4px;
   }
-  .world-if .TabView--Tab:nth-child(5) {
+  .world-if .TabView--more {
     width: calc(50% - 20px);
   }
-  .world-if .TabView--Tab:nth-child(5):hover {
+  .world-if .TabView--more:hover {
     background: none;
     width: calc(50% - 20px);
     background-color: #dedede;


### PR DESCRIPTION
The purpose of this implementation is split cusomised CSS (World if style) from the functional basic CSS to reuse the same component in the Re-vamp project.

To keep the WIF example alive a wrapped all the custom selectors in the .WorldIfApp NS.
Anyway, due to short time, I created a major for this implementation.

Out of scope
- Refactor world-if styles is of this implementation
- Refactor JS

Additional
Updated dev-pack
